### PR TITLE
Acis focal fix

### DIFF
--- a/ACIS_ft/acis_ft_fptemp.pl
+++ b/ACIS_ft/acis_ft_fptemp.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/local/bin/perl
+#!/usr/bin/env /usr/bin/perl
 
 #################################################################################
 #                                       										#
@@ -12,7 +12,8 @@
 #										                                        #
 #										                                        #
 #	noted by t. isobe							                                #
-#										                                        #
+#	                                                                            #
+#   replaced /usr/local/bin/perl with /usr/bin/perl in #! MS                    #
 #################################################################################
 
 while (read(STDIN, $buf, 8) == 8) {

--- a/ACIS_ft/create_5min_avg_data.py
+++ b/ACIS_ft/create_5min_avg_data.py
@@ -19,7 +19,7 @@ import getopt
 import random
 import time
 import Chandra.Time
-import Ska.engarchive.fetch as fetch
+#import Ska.engarchive.fetch as fetch
 import unittest
 #
 #--- reading directory list

--- a/ACIS_ft/create_5min_avg_data.py
+++ b/ACIS_ft/create_5min_avg_data.py
@@ -22,8 +22,7 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_5min_avg_data.py
+++ b/ACIS_ft/create_5min_avg_data.py
@@ -12,11 +12,8 @@
 
 import sys
 import os
-import string
 import re
 import numpy
-import getopt
-import random
 import time
 import Chandra.Time
 import Ska.engarchive.fetch as fetch
@@ -43,11 +40,6 @@ sys.path.append(mta_dir)
 sys.path.append(bin_dir)
 
 import mta_common_functions as mcf
-#
-#--- temp writing file name
-#
-rtail  = int(time.time() * random.random())
-zspace = '/tmp/zspace' + str(rtail)
 #
 #
 step  = 600.0   #---- 5 min step
@@ -227,8 +219,8 @@ if __name__ == "__main__":
     else:
         year = ''
 
-    #unittest.main(exit=False)
-    create_5min_avg_data(year)
+    unittest.main(exit=False)
+    #create_5min_avg_data(year)
 #
 #--- Remove lock file once process is completed
 #

--- a/ACIS_ft/create_5min_avg_data.py
+++ b/ACIS_ft/create_5min_avg_data.py
@@ -25,7 +25,8 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
+#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_focal_temperature_plots.py
+++ b/ACIS_ft/create_focal_temperature_plots.py
@@ -30,7 +30,8 @@ from matplotlib import gridspec
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
+#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_focal_temperature_plots.py
+++ b/ACIS_ft/create_focal_temperature_plots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /data/mta/Script/Python3.8/envs/ska3-shiny/bin/python
+#!/proj/sot/ska3/flight/bin/python
 
 #########################################################################################
 #                                                                                       #
@@ -19,6 +19,7 @@ import getopt
 import time
 import Chandra.Time
 import unittest
+import getpass
 
 import matplotlib as mpl
 mpl.use('Agg')
@@ -618,7 +619,38 @@ def change_ctime_to_ydate(cdate, yd=1):
         return [year, date]
 
 #-------------------------------------------------------------------------------
+#-- TEST   TEST   TEST   TEST   TEST   TEST   TEST   TEST   TEST   TEST   TEST -
+#-------------------------------------------------------------------------------
+
+class TestFunctions(unittest.TestCase):
+    """
+    testing functions
+    """
+#-------------------------------------------------------------------------------
+    def test_range_expand(self):
+        a = 314159
+        b = 525600
+        amin, amax = range_expand(a,b)
+        self.assertEqual(293014,amin)
+        self.assertEqual(546744,amax)
+#-------------------------------------------------------------------------------
+
+
 
 if __name__ == "__main__":
-
+#
+#--- Create a lock file and exit strategy in case of race conditions
+#
+    name = os.path.basename(__file__).split(".")[0]
+    user = getpass.getuser()
+    if os.path.isfile(f"/tmp/{user}/{name}.lock"):
+        sys.exit(f"Lock file exists as /tmp/{user}/{name}.lock. Process already running/errored out. Check calling scripts/cronjob/cronlog.")
+    else:
+        os.system(f"mkdir -p /tmp/mta; touch /tmp/{user}/{name}.lock")
+        
+    #unittest.main(exit=False)
     create_focal_temperature_plots()
+#
+#--- Remove lock file once process is completed
+#
+    os.system(f"rm /tmp/{user}/{name}.lock")

--- a/ACIS_ft/create_focal_temperature_plots.py
+++ b/ACIS_ft/create_focal_temperature_plots.py
@@ -12,10 +12,8 @@
 
 import sys
 import os
-import string
 import re
 import numpy
-import getopt
 import time
 import Chandra.Time
 import unittest
@@ -48,12 +46,6 @@ sys.path.append(mta_dir)
 sys.path.append(bin_dir)
 
 import mta_common_functions     as mcf
-#
-#--- temp writing file name
-#
-import random
-rtail  = int(time.time() * random.random())
-zspace = '/tmp/zspace' + str(rtail)
 
 d_in_sec = 86400.0
 

--- a/ACIS_ft/create_focal_temperature_plots.py
+++ b/ACIS_ft/create_focal_temperature_plots.py
@@ -28,8 +28,7 @@ from matplotlib import gridspec
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_html_pages.py
+++ b/ACIS_ft/create_html_pages.py
@@ -12,7 +12,6 @@
 
 import sys
 import os
-import string
 import re
 import time
 import unittest

--- a/ACIS_ft/create_html_pages.py
+++ b/ACIS_ft/create_html_pages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /data/mta/Script/Python3.8/envs/ska3-shiny/bin/python
+#!/proj/sot/ska3/flight/bin/python
 
 #########################################################################################
 #                                                                                       #
@@ -16,6 +16,7 @@ import string
 import re
 import time
 import unittest
+import getpass
 #
 #--- reading directory list
 #
@@ -166,6 +167,15 @@ def create_plintbl(year):
 #-------------------------------------------------------------------------------
 
 if __name__ == "__main__":
+#
+#--- Create a lock file and exit strategy in case of race conditions
+#
+    name = os.path.basename(__file__).split(".")[0]
+    user = getpass.getuser()
+    if os.path.isfile(f"/tmp/{user}/{name}.lock"):
+        sys.exit(f"Lock file exists as /tmp/{user}/{name}.lock. Process already running/errored out. Check calling scripts/cronjob/cronlog.")
+    else:
+        os.system(f"mkdir -p /tmp/mta; touch /tmp/{user}/{name}.lock")
 
     if len(sys.argv) > 1:
         all = 1
@@ -173,3 +183,7 @@ if __name__ == "__main__":
         all = 0
 
     run_html_page_script(all)
+#
+#--- Remove lock file once process is completed
+#
+    os.system(f"rm /tmp/{user}/{name}.lock")

--- a/ACIS_ft/create_html_pages.py
+++ b/ACIS_ft/create_html_pages.py
@@ -19,8 +19,7 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_html_pages.py
+++ b/ACIS_ft/create_html_pages.py
@@ -20,7 +20,8 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
+#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_long_term_max_data.py
+++ b/ACIS_ft/create_long_term_max_data.py
@@ -22,8 +22,7 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_long_term_max_data.py
+++ b/ACIS_ft/create_long_term_max_data.py
@@ -12,12 +12,9 @@
 
 import sys
 import os
-import string
 import re
 import numpy
-import getopt
 import time
-import random
 import Chandra.Time
 import Ska.engarchive.fetch as fetch
 import unittest
@@ -43,12 +40,7 @@ sys.path.append(mta_dir)
 sys.path.append(bin_dir)
 
 import mta_common_functions as mcf
-#
-#--- temp writing file name
-#
-rtail  = int(time.time() * random.random())
-zspace = '/tmp/zspace' + str(rtail)
-#
+
 step  = 86400   #---- one day step
 hstep = 0.5 * step
 

--- a/ACIS_ft/create_week_long_plot.py
+++ b/ACIS_ft/create_week_long_plot.py
@@ -29,8 +29,7 @@ from matplotlib import gridspec
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_week_long_plot.py
+++ b/ACIS_ft/create_week_long_plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /data/mta/Script/Python3.8/envs/ska3-shiny/bin/python
+#!/proj/sot/ska3/flight/bin/python
 
 #########################################################################################
 #                                                                                       #
@@ -19,6 +19,7 @@ import getopt
 import time
 import Chandra.Time
 import unittest
+import getpass
 
 import matplotlib as mpl
 mpl.use('Agg')
@@ -581,9 +582,24 @@ def change_ctime_to_ydate(cdate, yd=1):
 #-------------------------------------------------------------------------------
 
 if __name__ == "__main__":
+#
+#--- Create a lock file and exit strategy in case of race conditions
+#
+    name = os.path.basename(__file__).split(".")[0]
+    user = getpass.getuser()
+    if os.path.isfile(f"/tmp/{user}/{name}.lock"):
+        sys.exit(f"Lock file exists as /tmp/{user}/{name}.lock. Process already running/errored out. Check calling scripts/cronjob/cronlog.")
+    else:
+        os.system(f"mkdir -p /tmp/mta; touch /tmp/{user}/{name}.lock")
 
     if len(sys.argv) > 1:
         year = int(sys.argv[1])
     else:
         year = ''
+        
     create_week_long_plot(year)
+
+#
+#--- Remove lock file once process is completed
+#
+    os.system(f"rm /tmp/{user}/{name}.lock")

--- a/ACIS_ft/create_week_long_plot.py
+++ b/ACIS_ft/create_week_long_plot.py
@@ -31,7 +31,8 @@ from matplotlib import gridspec
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
+#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/create_week_long_plot.py
+++ b/ACIS_ft/create_week_long_plot.py
@@ -12,14 +12,12 @@
 
 import sys
 import os
-import string
 import re
-import numpy
-import getopt
 import time
 import Chandra.Time
 import unittest
 import getpass
+import datetime
 
 import matplotlib as mpl
 mpl.use('Agg')

--- a/ACIS_ft/fp_run_main_script
+++ b/ACIS_ft/fp_run_main_script
@@ -1,20 +1,9 @@
-cd /data/mta4/testACIS/Focal/Script/
+cd /data/mta/Script/ACIS/Focal/Script/
 
-/data/mta4/testACIS/Focal/Script/update_base_data.py
-/data/mta4/testACIS/Focal/Script/full_focal_plane_data.py 
-/data/mta4/testACIS/Focal/Script/create_5min_avg_data.py
-/data/mta4/testACIS/Focal/Script/create_long_term_max_data.py
-/data/mta4/testACIS/Focal/Script/create_focal_temperature_plots.py
-/data/mta4/testACIS/Focal/Script/create_week_long_plot.py
-/data/mta4/testACIS/Focal/Script/create_html_pages.py
-
-
-#cd /data/mta/Script/ACIS/Focal/Script/
-
-#/data/mta/Script/ACIS/Focal/Script/update_base_data.py
-#/data/mta/Script/ACIS/Focal/Script/full_focal_plane_data.py 
-#/data/mta/Script/ACIS/Focal/Script/create_5min_avg_data.py
-#/data/mta/Script/ACIS/Focal/Script/create_long_term_max_data.py
-#/data/mta/Script/ACIS/Focal/Script/create_focal_temperature_plots.py
-#/data/mta/Script/ACIS/Focal/Script/create_week_long_plot.py
-#/data/mta/Script/ACIS/Focal/Script/create_html_pages.py
+/data/mta/Script/ACIS/Focal/Script/update_base_data.py
+/data/mta/Script/ACIS/Focal/Script/full_focal_plane_data.py 
+/data/mta/Script/ACIS/Focal/Script/create_5min_avg_data.py
+/data/mta/Script/ACIS/Focal/Script/create_long_term_max_data.py
+/data/mta/Script/ACIS/Focal/Script/create_focal_temperature_plots.py
+/data/mta/Script/ACIS/Focal/Script/create_week_long_plot.py
+/data/mta/Script/ACIS/Focal/Script/create_html_pages.py

--- a/ACIS_ft/fp_run_main_script
+++ b/ACIS_ft/fp_run_main_script
@@ -1,9 +1,5 @@
 cd /data/mta/Script/ACIS/Focal/Script/
 
-setenv SKA /proj/sot/ska
-
-setenv PYTHONPATH "/data/mta/Script/Python3.8/envs/ska3-shiny/lib/python3.8/site-packages:/data/mta/Script/Python3.8/lib/python3.8/site-packages/"
-
 /data/mta/Script/ACIS/Focal/Script/update_base_data.py
 /data/mta/Script/ACIS/Focal/Script/full_focal_plane_data.py 
 /data/mta/Script/ACIS/Focal/Script/create_5min_avg_data.py

--- a/ACIS_ft/fp_run_main_script
+++ b/ACIS_ft/fp_run_main_script
@@ -1,9 +1,20 @@
-cd /data/mta/Script/ACIS/Focal/Script/
+cd /data/mta4/testACIS/Focal/Script/
 
-/data/mta/Script/ACIS/Focal/Script/update_base_data.py
-/data/mta/Script/ACIS/Focal/Script/full_focal_plane_data.py 
-/data/mta/Script/ACIS/Focal/Script/create_5min_avg_data.py
-/data/mta/Script/ACIS/Focal/Script/create_long_term_max_data.py
-/data/mta/Script/ACIS/Focal/Script/create_focal_temperature_plots.py
-/data/mta/Script/ACIS/Focal/Script/create_week_long_plot.py
-/data/mta/Script/ACIS/Focal/Script/create_html_pages.py
+/data/mta4/testACIS/Focal/Script/update_base_data.py
+/data/mta4/testACIS/Focal/Script/full_focal_plane_data.py 
+/data/mta4/testACIS/Focal/Script/create_5min_avg_data.py
+/data/mta4/testACIS/Focal/Script/create_long_term_max_data.py
+/data/mta4/testACIS/Focal/Script/create_focal_temperature_plots.py
+/data/mta4/testACIS/Focal/Script/create_week_long_plot.py
+/data/mta4/testACIS/Focal/Script/create_html_pages.py
+
+
+#cd /data/mta/Script/ACIS/Focal/Script/
+
+#/data/mta/Script/ACIS/Focal/Script/update_base_data.py
+#/data/mta/Script/ACIS/Focal/Script/full_focal_plane_data.py 
+#/data/mta/Script/ACIS/Focal/Script/create_5min_avg_data.py
+#/data/mta/Script/ACIS/Focal/Script/create_long_term_max_data.py
+#/data/mta/Script/ACIS/Focal/Script/create_focal_temperature_plots.py
+#/data/mta/Script/ACIS/Focal/Script/create_week_long_plot.py
+#/data/mta/Script/ACIS/Focal/Script/create_html_pages.py

--- a/ACIS_ft/fp_run_wrap_script
+++ b/ACIS_ft/fp_run_wrap_script
@@ -1,1 +1,2 @@
-TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta/Script/ACIS/Focal/Script/fp_run_main_script
+TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta4/testACIS/Focal/Script/fp_run_main_script
+#TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta/Script/ACIS/Focal/Script/fp_run_main_script

--- a/ACIS_ft/fp_run_wrap_script
+++ b/ACIS_ft/fp_run_wrap_script
@@ -1,2 +1,1 @@
-TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta4/testACIS/Focal/Script/fp_run_main_script
-#TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta/Script/ACIS/Focal/Script/fp_run_main_script
+TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta/Script/ACIS/Focal/Script/fp_run_main_script

--- a/ACIS_ft/fp_run_wrap_script
+++ b/ACIS_ft/fp_run_wrap_script
@@ -1,1 +1,1 @@
-/bin/tcsh  < /data/mta/Script/ACIS/Focal/Script/fp_run_main_script
+TERM=dummy; export TERM; /proj/sot/ska3/flight/bin/skare /bin/tcsh  < /data/mta/Script/ACIS/Focal/Script/fp_run_main_script

--- a/ACIS_ft/full_focal_plane_data.py
+++ b/ACIS_ft/full_focal_plane_data.py
@@ -20,8 +20,7 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/full_focal_plane_data.py
+++ b/ACIS_ft/full_focal_plane_data.py
@@ -24,7 +24,8 @@ import getpass
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
+#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/full_focal_plane_data.py
+++ b/ACIS_ft/full_focal_plane_data.py
@@ -12,11 +12,7 @@
 
 import sys
 import os
-import string
 import re
-import getopt
-import time
-import random
 import Chandra.Time
 import Ska.engarchive.fetch as fetch
 import unittest
@@ -42,11 +38,6 @@ sys.path.append(mta_dir)
 sys.path.append(bin_dir)
 
 import mta_common_functions as mcf
-#
-#--- temp writing file name
-#
-rtail  = int(time.time() * random.random())
-zspace = '/tmp/zspace' + str(rtail)
 
 #-------------------------------------------------------------------------------
 #-- create_full_focal_plane_data: create/update full resolution focal plane data
@@ -197,9 +188,7 @@ def create_full_focal_plane_data(rfile=''):
             continue
 #
 #--- if testing then return the file contents for assertEquals
-#  
-        #print(f"testout:{testout}")
-        #print(f"sline:{sline}")
+# 
         if testout == 1:
             return sline
 
@@ -343,12 +332,13 @@ def ptime_to_ctime(year, atime, chg):
 #
 #--- add leading zeros
 #
-    day   = mcf.add_leading_zero(day, 3)
-    hh    = mcf.add_leading_zero(hh,  2)
-    mm    = mcf.add_leading_zero(mm,  2)
-    ss    = mcf.add_leading_zero(ss,  2)
-    
-    yday  = str(year) + ':' + str(day) + ':' + str(hh) + ':' + str(mm) + ':' + str(ss)
+
+    day = str(day).zfill(3)
+    hh = str(hh).zfill(2)
+    mm = str(mm).zfill(2)
+    ss = str(ss).zfill(2)
+
+    yday = f'{year}:{day}:{hh}:{mm}:{ss}'
     try:
         ctime = Chandra.Time.DateTime(yday).secs
     except:
@@ -367,10 +357,10 @@ class TestFunctions(unittest.TestCase):
 #-------------------------------------------------------------------------------
 
     def test_find_cold_plates(self):
-        t_list = [638025960, 638243227, 637326500, 638572802]
+        t_list = [638025960, 638243227]
 
-        testa = [-123.14513244628904, -125.53862609863279, 999.0, -125.53862609863279]
-        testb = [-123.14513244628904, -125.53862609863279, 999.0, -123.14513244628904]
+        testa = [-123.14513244628904, -125.53862609863279]
+        testb = [-123.14513244628904, -125.53862609863279]
 
         [crat, crbt] = find_cold_plates(t_list)
 
@@ -392,7 +382,6 @@ class TestFunctions(unittest.TestCase):
 #-------------------------------------------------------------------------------
 
     def test_find_year_change(self):
-
         ifile = '/data/mta/Script/ACIS/Focal/Short_term/data_2017_365_2059_001_0241'
 
         [year, chg] = find_year_change(ifile)

--- a/ACIS_ft/getnrt
+++ b/ACIS_ft/getnrt
@@ -1,9 +1,7 @@
-#! /bin/env perl
-'di';
-'ig00';
+#!/usr/bin/env perl
 #-----------------------------------------------------------------------
 #
-#   Module Name:    $Source: /data/mta4/CVS/Acis_ft/getnrt,v $
+#   Module Name:    $Source: /nfs/acis/h3/acisfs/configcntl/tools/src/GSEtest/scripts/getnrt,v $
 #
 #   Purpose:        Translate ASCDS telemetry frames to packets
 #
@@ -20,8 +18,76 @@
 #   Copyright:      Massachusetts Institute of Technology 1998
 #
 #   $Log: getnrt,v $
-#   Revision 1.1.1.1  2006/04/06 19:09:53  mta
-#   Imported sources
+#   Revision 1.30  2012/12/20 16:00:10  pgf
+#   Improve bad EHS block detection and dscription of -D flag
+#
+#   Revision 1.29  2012/12/19 21:58:29  pgf
+#   Add -D flag to detect and suppress bad EHS blocks
+#
+#   Revision 1.28  2012/12/06 15:47:29  squid
+#   Replace gzcat with gunzip -c
+#
+#   Revision 1.27  2012/11/13 20:41:46  pgf
+#   Make compatible with Linux
+#
+#   Revision 1.26  2012/08/07 16:09:34  pgf
+#   Reformat attached manuals and split them into man/man1.
+#
+#   Revision 1.25  2012/05/30 14:19:11  pgf
+#   Improve roll-over detection.
+#
+#   Revision 1.24  2012/03/09 20:37:03  pgf
+#   Use Socket class when running in perl5
+#
+#   Revision 1.23  2012/03/07 21:05:18  pgf
+#   Reformat floats for LSB architectures
+#
+#   Revision 1.22  2012/03/07 18:08:24  pgf
+#   Open compressed files with gzcat or zcat, for linux compliance
+#
+#   Revision 1.21  2011/06/08 21:22:56  pgf
+#   Update online manual section.
+#
+#   Revision 1.20  2011/05/11 17:58:41  pgf
+#   Add -o option.
+#
+#   Revision 1.19  2010/07/09 15:04:45  pgf
+#   Discard null minor frames.
+#
+#   Revision 1.18  2010/06/21 15:19:23  pgf
+#   Only reject minor frames with flagged errors.
+#
+#   Revision 1.17  2009/01/22 19:16:28  pgf
+#   Fix previous update.
+#
+#   Revision 1.16  2009/01/22 19:06:44  pgf
+#   Prevent integer truncation error in some versions of Perl.
+#
+#   Revision 1.15  2006/04/03 17:49:45  pgf
+#   Begin with generic search for Perl interpreter in $PATH
+#
+#   Revision 1.14  2005/04/25 03:01:40  pgf
+#   Replace missing minor frames with the correct number of nuls.
+#
+#   Revision 1.13  2005/03/26 07:27:47  pgf
+#   Fix typo in printEng().
+#
+#   Revision 1.12  2005/03/25 18:54:35  pgf
+#   Add -V option to display packet header fields.
+#
+# Revision 1.11  2001/07/05  21:30:16  pgf
+# account for wraparound in extra frame counter
+#
+# Revision 1.10  2001/03/16  19:45:14  pgf
+# add -u flag for unbuffered output
+# recognize (tcp|udp):host:port input format.
+#
+# Revision 1.9  2000/08/14  14:28:26  pgf
+# report header fields in verbose messages
+# pass only 1025 bytes of each minor frame
+#
+# Revision 1.8  1999/12/22  22:54:32  pgf
+# Update to interpret VCDU with external fencepost file
 #
 # Revision 1.7  1999/10/10  17:23:18  pgf
 # fix error in science frame time value
@@ -72,30 +138,38 @@
 #-----------------------------------------------------------------------
 
 $USAGE = "$0
-	[-C]		# check VCDU counters
-	[-F file]	# override ACISTTMFILE value
-	[-G]		# use ground receipt times
-	[-M]		# use mission elapsed times
-	[-O]		# use on-board times
-	[-R]		# allow for VCDU rollover
-	[-T time]	# supply time tags based on VCDU
-	[-n frames]	# max extra frames to ignore
-	[-r rolls]	# number of VCDU rollovers since fence start
-	[-t file]	# get time from fencepost file
-	[-v]		# verbose
-	[-x]		# report eng only once per major frame
-	[-X]		# old-style format 1
-	[file]		# input file name
+	[-C]            # report VCDU jumps and bad EHS frames
+	[-D]            # detect and remove bad EHS frames
+	[-F file]       # override ACISTTMFILE value
+	[-G]            # use ground receipt times
+	[-M]            # use mission elapsed times
+	[-O]            # use on-board times
+	[-R]            # allow for VCDU rollover
+	[-T time]       # supply time tags based on VCDU
+	[-V]            # print packet info to STDERR
+	[-X]            # old-style format 1
+	[-n frames]     # max extra frames to ignore
+	[-o path]       # raw output file
+	[-r rolls]      # number of VCDU rollovers since fence start
+	[-t file]       # get time from fencepost file
+	[-u]            # use unbuffered output
+	[-v]            # verbose
+	[-x]            # report eng only once per major frame
+	[file]          # input file name
 ";
 #-----------------------------------------------------------------------
-$ttm = $ENV{ACISTTMFILE} ? $ENV{ACISTTMFILE} : "acisEng.ttm";
+
+#require "ctime.pl";
+
+$ttm = $ENV{ACISTTMFILE} ? $ENV{ACISTTMFILE} : "/data/mta/Script/MTA_limit_trends/Scripts/DEA/lib/acisEng.ttm";
 $nul = pack('C', 0);
 $xb7 = pack('C', 0xb7);
 #-----------------------------------------------------------------------
 # parse command arguments
 while ($_ = shift(@ARGV)) {
-    /^-[FTnrt]$/ && ($_ .= shift(@ARGV));
+    /^-[FTnort]$/ && ($_ .= shift(@ARGV));
     /^-C$/      && ($ckmnf   = 1 )     && next;
+    /^-D$/      && ($Dflag   = 1 )     && next;
     /^-F(.+)/   && ($ttm     = $1)     && next;
     /^-G$/      && ($timeoff = 4 )     && next;
     /^-M$/      && ($timeoff = 36)     && next;
@@ -103,71 +177,91 @@ while ($_ = shift(@ARGV)) {
     /^-R$/      && ($roll    = 1)      && next;
     /^-T(.+)/   && ($time    = $1)     && next;
     /^-X$/      && ($oldfmt1 = 1 )     && next;
+    /^-V$/      && ($Vverbose = 1 )    && next;
     /^-n(\d+)$/ && (($extras = $1)||1) && next;
+    /^-o(.+)/   && ($ofile   = "$1")   && next;
     /^-r(\d+)$/ && (($rolls  = $1)||1) && next;
     /^-t(.+)/   && &readFence($1)      && next;
+    /^-u$/	&& ($|       = 1 )     && next;
     /^-x$/      && ($xflag   = 1 )     && next;
     /^-v$/      && ($verbose = 1 )     && next;
     /^[^-]/     && unshift(@ARGV, $_)  && last;
     die $USAGE;
 }
+@ARGV = ( 'stdin' ) unless $ARGV[0];
 #-----------------------------------------------------------------------
 # read channel locations
 %chan = &readLib($ttm);
 &sortFence if @Gfence;
-
-@ARGV = ( 'stdin' ) unless $ARGV[0];
+#-----------------------------------------------------------------------
+# open raw output file if requested
+! $ofile || open(OUT, ">$ofile") || die "$ofile: $!\n";
 #-----------------------------------------------------------------------
 # diagnostic messages
-$msg1 = "lpkt=%d stat=%04x opts=%02x mask=%02x%02x%02x%02x\n";
+$msg1 = "lpkt=%d lhdr=%d stat=%04x nmnf=%d opts=%02x mask=%02x%02x%02x%02x\n";
 $msg2 = "%d %6d:%03d %8d\n";
 $msg3 = "%s: %s %2d minor frame(s) %d:%03d - %d:%03d fmt %d byte +%d\n";
 $msg4 = "%s: bad ACIS serial byte 0x%02x in %d:%03d\n";
 $msg5 = "%s: bad minor frame offset %d in %d:%03d\n";
 $msg6 = "%s: %s at %04d/%03d/%09.3f vcdu %d:%03d\n";
 $msg7 = "%s: VCDU rollover at %d:%03d - %d:%03d\n";
+$msg8 = "%s: null minor frame ignored after vcdu %d:%03d\n";
+$msg9 = "%s: rejected EHS block %d:%03d scid %d fmt %d byte +%d\n";
+&setProg if $Vverbose;
 #-----------------------------------------------------------------------
 # read OCC telemetry blocks, extract minor frames
 for $file (@ARGV) {
-    local($org, $first);
+    local($org, $first, $lpkt);
     # if necessary, decompress the file
-    if ($file =~ /\.(gz|Z)$/) {
-	open(STDIN, "gzcat $file|") || die "$file: $!\n";
+    if ($file =~ /^(tcp|udp):\/\/([^:]+):([^:]+)$/) {
+	$port = &openPort($1, $2, $3);
+    } elsif ($file =~ /\.(gz|Z)$/) {
+	open(STDIN, "gunzip -cf $file|") || die "$file: $!\n";
     } elsif ($file ne 'stdin') {
 	open(STDIN, $file) || die "$file: $!\n";
     }
     # read the primary EHS header
-    while (read(STDIN, $_, 16) == 16) {
-	local($lpkt) = unpack("x14n", $_);
-	# read the rest of the EHS packet
-	last if $lpkt < 16 || read(STDIN, $_, $lpkt-16, 16) != ($lpkt-16);
+    for ($org = 0; ; $org += $lpkt) {
+	if ($port) {
+	    last unless recv(STDIN, $_, 8192, 0);
+	    $lpkt = unpack("x14n", $_);
+	} else {
+	    last unless read(STDIN, $_, 16) == 16;
+	    $lpkt = unpack("x14n", $_);
+	    # read the rest of the EHS packet
+	    last if $lpkt < 16 || read(STDIN, $_, $lpkt-16, 16) != ($lpkt-16);
+	}
+	print OUT if $ofile;
 	local($lhdr, $stat, $nmnf, $opts) = unpack("x16n2x14C2", $_);
 	if (($stat & 3) != 3 && ($stat & 0x8000) == 0) {
 	    local($obtflg, $nn, @mask) = $opts & 0x40;
 	    # read the optional minor frame status bytes
 	    @mask = unpack('C*', substr($_, $obtflg ? 52 : 36, $nmnf+1))
 		if $stat & 3;
+	    # ignore bad frames
+	    next if $Dflag && &test_frame();
 	    # decode the appropriate timestamp
+	    printf STDERR $msg1, $lpkt, $lhdr, $stat, $nmnf+1, $opts, @mask
+		if $verbose;
 	    &get_frame_time if ! ($stat & 3) && ($obtflg || $timeoff == 4);
-	    printf STDERR $msg1, $lpkt, $stat, $opts, @mask if $verbose;
 	    # process each minor frame
 	    for ($nn = 0; $nn <= $nmnf; $nn++) {
-		local($off) = $lhdr+130+1134*$nn;
+		local($off) = $lhdr+126+1134*$nn;
 		if ($off < 0 || $off >= length($_)) {
-		    printf STDERR $msg5, $file, $off,
+		    printf STDERR $msg5, &fName, $off,
 			$lastmajor & 131071, $lastminor;
-		} elsif (! $mask[$nn]) {
+		} elsif (($mask[$nn] & 0x77) == 0) {
 		    &proc_frame(substr($_, $off, 1029));
 		}
 		&incr_frame_time if $timeoff;
 	    }
 	}
-	$org += $lpkt;
     }
     # report the last VCDU if -C used
-    printf STDERR $msg6, $file, "ends", $year, $doy, $sec,
+    printf STDERR $msg6, &fName, "ends", $year, $doy, $sec,
         $lastmajor & 131071, $lastminor if $ckmnf;
     close(STDIN);
+    close(OUT) if $ofile;
 }
 #-----------------------------------------------------------------------
 # cleanup
@@ -177,24 +271,55 @@ for $file (@ARGV) {
 close(STDIN);
 exit(0);
 #-----------------------------------------------------------------------
+# examine VCDU headers in EHS block
+sub test_frame { # -> {1|0}
+    local($sw, $nn, $sc, $vv, $ff, $vv0, $ff0, @buf) = (0);
+    for ($nn = 0; $nn <= $nmnf; $nn++) {
+	# ignore if flagged bad in EHS header
+	next if $mask[$nn] & 0x77;
+	@buf = unpack('x'.($lhdr+126+1134*$nn).'N3', $_);
+	# extract format and vcdu
+	$sc = ($buf[1] >> 22) & 0xff;
+	$ff = (($buf[1] >> 16) & 7) + 1;
+	$vv = (($buf[1] & 0xffff) << 8) | (($buf[2] >> 24) & 0xff);
+	# ignore if spacecraft code or format incorrect
+	last if ($sc != 6 || $ff > 6) && ++$sw;
+	# formats must be identical within the block
+	last if $ff0 && $ff != $ff0 && ++$sw;
+	# consecutive good vcdus must be ascending
+	last if $vv0 && ($vv <= $vv0 || $vv > $vv0+127) && ++$sw;
+	$ff0 = $ff;
+	$vv0 = $vv;
+    }
+    printf STDERR $msg9, $file, $vv >> 7, $vv & 0x7f,
+	$sc, $ff, $org if $sw && $ckmnf;
+    return $sw;
+}
+#-----------------------------------------------------------------------
 # extract ACIS science and engineering from a minor frame
 sub proc_frame { # minor-frame-buffer -> nul
     local($tlm) = shift;
-    local(@buf) = unpack('N2', $tlm);
+    local($synch, @buf) = unpack('N3', $tlm);
     local($fmt) = (($buf[0] >> 16) & 7) + 1;
     local($major) = (($buf[0] & 0xffff) << 1) | (($buf[1] >> 31) & 1);
     local($minor) = ($buf[1] >> 24) & 0x7f;
 
+    # check for null minor frame
+    if ($synch == 0 && $major == 0 && $minor == 0) {
+	printf STDERR $msg8, $file, $lastmajor, $lastminor;
+	return;
+    }
+
     # handle VCDU rollover
-    if ($roll && $major < 32768 && ($lastmajor & 131071) > (131072-32768)) {
+    if ($roll && ($major & 131071)+100 < ($lastmajor & 131071)) {
 	$rolls++;
-	printf STDERR $msg7, $file, $lastmajor & 131071, $lastminor,
+	printf STDERR $msg7, &fName, $lastmajor & 131071, $lastminor,
 	    $major & 131071, $minor if $verbose || $ckmnf;
     }
     $major += $rolls << 17;
 
     # report the first VCDU if -C used
-    printf STDERR $msg6, $file, "starts", $year, $doy, $sec,
+    printf STDERR $msg6, &fName, "starts", $year, $doy, $sec,
         $major & 131071, $minor if $ckmnf && ($year || $doy) && ! $first++;
 
     # report the VCDU information and byte offset
@@ -202,16 +327,26 @@ sub proc_frame { # minor-frame-buffer -> nul
 
     # report missing or extra minor frames
     if ($nminor++) {
-	$n = 128*($major-$lastmajor)+$minor-$lastminor-1;
-	if ($n > 0) {
+	local($nn) = 128*($major-$lastmajor)+$minor-$lastminor-1;
+	if ($nn > 0) {
 	    # for missing frames, add NUL padding to science packets
-	    printf STDERR $msg3, $file, "missing", $n, $lastmajor & 131071,
+	    printf STDERR $msg3, &fName, "missing", $nn, $lastmajor & 131071,
 		$lastminor, $major & 131071, $minor, $fmt, $org if $ckmnf;
-	    $acis .= $nul x ($n * 16) if $fmt == 1;
-	    $acis .= $nul x ($n * 768) if $fmt == 2;
-	} elsif ($n < -$extras) {
+	    # add nuls to $acis
+	    if ($fmt == 1 || $fmt == 2) {
+		local($mm) = 0;
+		while (--$nn >= 0 && $mm < 4096) {
+		    if (++$lastminor & 7) {
+			$mm += ($fmt == 1 ? 16 : 768);
+		    } else {
+			$mm += ($fmt == 1 ? 12 : 740);
+		    }
+		}
+		$acis .= $nul x $mm;
+	    }
+	} elsif ($nn < -$extras) {
 	    # ignore duplicate frames entirely
-	    @ndup = ($major, $minor) unless $ndup++;
+	    @ndup = ($major & 131071, $minor) unless $ndup++;
 	    return;
 	}
     }
@@ -219,7 +354,7 @@ sub proc_frame { # minor-frame-buffer -> nul
     # report duplicate frames
     if ($ndup) {
 	printf STDERR
-	    $msg3, $file, "extra  ", $ndup, @ndup, $lastmajor & 131071,
+	    $msg3, &fName, "extra  ", $ndup, @ndup, $lastmajor & 131071,
 		$lastminor, $fmt, $org if $ckmnf;
 	$ndup = 0;
     }
@@ -228,7 +363,7 @@ sub proc_frame { # minor-frame-buffer -> nul
 	    
     # get engineering data
     for (split(' ', $chan{"$fmt.$minor"})) {
-	$eng .= substr($tlm, $_, 1).pack('Cv', $minor, $_);
+	$eng .= substr($tlm, $_+4, 1).pack('Cv', $minor, $_);
     }
 	    
     # print separate engineering records in format 4 only
@@ -237,16 +372,16 @@ sub proc_frame { # minor-frame-buffer -> nul
     # copy science data to $acis
     if ($fmt == 1) {
 	if ($minor & 7) {
-	    $acis .= substr($tlm, $oldfmt1 ? 256 : 526, 4);
+	    $acis .= substr($tlm, $oldfmt1 ? 260 : 530, 4);
 	} else {
-	    &printTime(substr($tlm, $oldfmt1 ? 256 : 526, 4));
+	    &printTime(substr($tlm, $oldfmt1 ? 260 : 530, 4));
 	}
-	$acis .= substr($tlm, $oldfmt1 ? 260 : 768, 12);
+	$acis .= substr($tlm, $oldfmt1 ? 264 : 772, 12);
     } elsif ($fmt == 2) {
-	&printTime(substr($tlm, 56, 4)) unless $minor & 7;
+	&printTime(substr($tlm, 60, 4)) unless $minor & 7;
 	local($off) = ($minor & 7) ? 0 : 28;
 	for ($i = 0; $i < 8; $i++, $off = 0) {
-	    $acis .= substr($tlm, 32+$off+128*$i, 96-$off);
+	    $acis .= substr($tlm, 36+$off+128*$i, 96-$off);
 	}
     } else {
 	&printTime($nul x 4) unless $minor & 7;
@@ -254,6 +389,35 @@ sub proc_frame { # minor-frame-buffer -> nul
     
     # process the science data
     &procBuf if $acis;
+}
+#-----------------------------------------------------------------------
+# return file name for messages
+sub fName {
+    local($name) = $file;
+    $name =~ s/^.*\/([^\/]+)$/\1/;
+    $name .= substr(&ctime(time), 3, 13) if $port;
+    return $name;
+}
+#-----------------------------------------------------------------------
+# read data from IP port
+sub openPort {
+    local($proto, $host, $port, $pn, $at, $paddr) = @_;
+    close(STDIN);
+    # the following protects 'use' etc from failing to compile in perl 4.
+    if ($] =~ /^[^\d]*(\d+)/ && $1 < 5) {
+	eval `h2ph -d /tmp - < /usr/include/sys/socket.h | grep -v require`;
+	sub inet_aton { (gethostbyname($_[0]))[4]; }
+	sub pack_sockaddr_in { pack('Sna4x8', &AF_INET, $_[0], $_[1]); }
+    } else {
+	eval 'use Socket';
+    }
+    die "$proto: unknown protocol\n" unless $pn = getprotobyname($proto);
+    die "$host: host unknown\n" unless $at = &inet_aton($host);
+    die "$host:$port: $!\n" unless $paddr = &pack_sockaddr_in($port, $at);
+    die "socket: $!\n" unless socket(STDIN, &PF_INET, &SOCK_DGRAM, $pn);
+    die "$host:$port: bind $!\n" unless bind(STDIN, $paddr);
+    printf STDERR "%s: listening on $host port $port\n", &fName;
+    return $port;
 }
 #-----------------------------------------------------------------------
 # read channel locations
@@ -272,10 +436,10 @@ sub readLib {
 # output an engineering pseudopacket
 sub printEng {
     if ($eng) {
-	print pack('V4', 0x736f4166, (61<<10)+4+int(length($eng)/4),
-		   $fmt, $lastmajor & 131071);
-	print $eng;
+	local($hdr) = (61<<10)+4+int(length($eng)/4);
+	print pack('V4', 0x736f4166, $hdr, $fmt, $lastmajor & 131071).$eng;
 	$eng = '';
+	&printVerbose($hdr) if $Vverbose;
     }
     $lastmajor = $major;
 }
@@ -302,18 +466,18 @@ sub printTime { # BEP-timestamp-string -> nul
 	$lastsec = $sec;
 	@irig = &pack_irig($doy, $sec);
     } else {
-	@irig = unpack('x32n3', $tlm);
+	@irig = unpack('x36n3', $tlm);
     }
     print pack('V4v4', 0x736f4166, (62<<10)+7, $fmt,
-	$major & 131071, $minor, @irig);
-    print shift;
+	$major & 131071, $minor, @irig).shift;
+    &printVerbose((62<<10)+7) if $Vverbose;
 }
 #-----------------------------------------------------------------------
 # convert day and second to IRIG-B format
 sub pack_irig { # doy, sec -> (irig)
     local($d, $s) = @_;
-    local($id, $is, $ms, $us) = (int($d), int($s),
-	int(1000*$s) % 1000, int(1000000*$s) % 1000);
+    local($id, $is, $ms) = (int($d), int($s), int(1000*$s) % 1000);
+    local($us) =  int(1000000.5*($s-$is) % 1000);
     return (($id << 5) | ($is >> 12), (($is & 0xfff) << 4) | ($ms >> 6),
 	(($ms & 0x3f) << 10) | ($us & 0x3ff));
 }
@@ -366,11 +530,13 @@ sub procBuf { # nul -> nul
 	    $ch = substr($acis, $off+$len, 1);
 	    if ($ch ne $xb7 && $ch ne 'f') {
 		printf STDERR
-		    $msg4, $file, unpack('C', $ch),
+		    $msg4, &fName, unpack('C', $ch),
 			$major & 131071, $minor if $ckmnf;
 		$len = 4;
 	    } else {
 		print substr($acis, $off, $len);
+		&printVerbose(unpack("V", substr($acis, $off+4, 4)))
+		    if $Vverbose;
 	    }
 	}
 	$acis = substr($acis, $off+$len);
@@ -382,9 +548,15 @@ sub procBuf { # nul -> nul
 sub readFence {
     local($file) = shift;
     open(file) || die "$file: $!\n";
+    local($msb) = substr(pack("L", 1), 3, 1) eq pack("C", 1);
     while (read(file, $_, 170) == 170) {
 	unpack("l", $_) == 0 && read(file, $_, 337) && next;
-	push(@Gfence, unpack("x16 d2 x32 d2", $_));
+	if ($msb) {
+	    push(@Gfence, unpack("x16 d2 x32 d2", $_));
+	} else {
+	    local(@A) = unpack("x16 V4 x32 V4", $_);
+	    push(@Gfence, unpack("d4", pack("N8", @A[1,0,3,2,5,4,7,6])));
+	}
     }
     close(file);
     return 1;
@@ -429,12 +601,40 @@ sub getFence {
     return ($DDfence+1, $s);
 }
 #-----------------------------------------------------------------------
-__END__
-.00
+# initialize array of packet names
+sub setProg {
+@prog = (
+  '',                    'bepReadReply',        'fepReadReply',
+  'sramReadReply',       'pramReadReply',       'bepExecuteReply',
+  'fepExecuteReply',     'commandEcho',         'bepStartupMessage',
+  'fatalMessage',        'swHousekeeping',      'deaHousekeepingData',
+  'dumpedTeBlock',       'dumpedCcBlock',       'dataTeBiasMap',
+  'scienceReport',       'exposureTeRaw',       'dataTeRaw',
+  'exposureTeHistogram', 'dataTeHist',          'exposureTeFaint',
+  'dataTeFaint',         'exposureTeFaintBias', 'dataTeFaintBias',
+  'exposureTeGraded',    'dataTeGraded',        'exposureCcRaw',
+  'dataCcRaw',           'exposureCcFaint',     'dataCcFaint',
+  'exposureCcGraded',    'dataCcGraded',        'dataCcBiasMap',
+  'dataBiasError',       'bepReadReply',        'bepReadReply',
+  'bepReadReply',        'bepReadReply',        'bepReadReply',
+  'bepReadHuffman',      'bepReadSlots',        'bepReadSlots',
+  'bepReadSlots',        'bepReadSlots',        'bepReadSlots',
+  '',                    'dataTeVeryFaint',     'exposureTeVeryFaint',
+  'dataTeEvHist',        'exposureTeEvHistogram', 'patchDataBiasError',
+  'dataTeFaint',         'exposureCcFaint',     'dataTeGraded',
+  'exposureCcGraded',    'dataTeCti1',          'exposureTeCti1',
+  );
 
-'di
-.nr nl 0-1
-.nr % 0
+  @prog[61..63] = ('engineeringPseudo', 'scienceFramePseudo', 'userPseudo');
+}
+#-----------------------------------------------------------------------
+# report packet name and VCDU to STDERR
+sub printVerbose {
+    printf STDERR "%07d:%03d: %5d %4d %s\n", $major, $minor,
+    ($_[0] >> 16) & 0xffff, $_[0] & 0x3ff, $prog[($_[0] >> 10) & 63];
+}
+#-----------------------------------------------------------------------
+__END__
 .TH GETNRT 1 "April 10, 1998"
 .\" --------------------------------------------------------------------
 .SH NAME
@@ -442,7 +642,7 @@ getnrt \- translate ASCDS telemetry stream to ACIS packets and pseudopackets
 .\" --------------------------------------------------------------------
 .SH SYNOPSIS
 .B getnrt
-.RB [ \-CGMORXvx ]
+.RB [ \-CDGMORXuvx ]
 .RB [ \-F
 .IR ttmfile ]
 .RB [ \-T
@@ -467,6 +667,22 @@ or
 .I
 ".Z",
 it will be decompressed while reading.
+.LP
+Alternatively, a
+.I file
+name of the form
+.I
+"proto://hostname:port"
+will read IP datagram packets in
+.I proto
+protocol (either
+.B tcp
+or
+.BR udp )
+from the specified
+.I port
+of
+.IR hostname .
 .LP
 Timing information will be extracted from the 6-byte IRIG-B fields in
 science frame headers unless overridden by the contents of a \`\`fencepost\'\'
@@ -504,6 +720,18 @@ otherwise, it is ignored.
 writes an error message to
 .I stderr
 whenever a gap in minor frames is detected.
+.\" ------------------------------------
+.TP 8n
+.B \-D
+removes corrupted EHS blocks. If found, and if the
+.B \-C
+flag is also specified,
+.I getnrt
+writes an error message to
+.I stderr
+to report the VCDU time tag, the spacecraft ID (which should be 6 for
+Chandra), the telemetry format (which should not exceed 6), and the
+byte offset of the start of the EHS block in the uncompressed input file.
 .\" ------------------------------------
 .TP 8n
 .BI \-F " ttmfile"
@@ -579,6 +807,19 @@ minor frame), where
 supplies the starting value in seconds elapsed since Jan 1 1970, UTC.
 .\" ------------------------------------
 .TP 8n
+.BI \-V
+For each ACIS packet encountered, write a line to
+.I stderr
+listing the major and minor frame values of the start of the packet,
+its sequence number, 32-bit word length, and mnemonic.
+.\" ------------------------------------
+.TP 8n
+.B \-X
+causes
+.I getp
+to use the old pre-flight byte assignment in Format 1.
+.\" ------------------------------------
+.TP 8n
 .BI \-n " frames"
 ignore duplicate minor frames whose major frame index differs from the
 previous acceptable frame by no more than
@@ -588,6 +829,13 @@ if consecutive frames are received with VCDU major:minor frame indices
 "5:31, 5:32, 2:33, 5:34, 5:35", the third minor frame will be ignored if
 .I frames
 is 3 or less.
+.\" ------------------------------------
+.TP 8n
+.BI \-o " file"
+copy the input to
+.I file
+without making any changes or deletions. This is particularly useful
+when reading from a port or from a combination of files and port.
 .\" ------------------------------------
 .TP 8n
 .BI \-r " rolls"
@@ -606,6 +854,11 @@ indices according to the contents of
 a valid Chandra timing \`\`fencepost\'\' file.
 .\" ------------------------------------
 .TP 8n
+.B \-u
+uses unbuffered output to
+.IR stdout .
+.\" ------------------------------------
+.TP 8n
 .B \-v
 becomes
 .I very
@@ -615,12 +868,6 @@ verbose, listing fields within each OCC and minor frame header.
 .B \-x
 report engineering pseudopackets once per major frame, even in Format 4,
 when 5 ACIS channels are present in each minor frame.
-.\" ------------------------------------
-.TP 8n
-.B \-X
-causes
-.I getp
-to use the old pre-flight byte assignment in Format 1.
 .\" --------------------------------------------------------------------
 .SH AUTHOR
 Peter G. Ford, MIT CSR

--- a/ACIS_ft/house_keeping/dir_list
+++ b/ACIS_ft/house_keeping/dir_list
@@ -1,7 +1,7 @@
-'/data/mta4/testACIS/Focal/Script/'               : bin_dir
-'/data/mta4/testACIS/Focal/Script/house_keeping/' : house_keeping
-'/data/mta4/testACIS/Focal/web/'                             : web_dir
-'/data/mta4/testACIS/Focal/web/Plots/'                       : plot_dir
-'/data/mta4/testACIS/Focal/Data/'                 : data_dir
-'/data/mta4/testACIS/Focal/Short_term/'           : short_term
+'/data/mta/Script/ACIS/Focal/Script/'               : bin_dir
+'/data/mta/Script/ACIS/Focal/Script/house_keeping/' : house_keeping
+'/data/mta/www/mta_fp/'                             : web_dir
+'/data/mta/www/mta_fp/Plots/'                       : plot_dir
+'/data/mta/Script/ACIS/Focal/Data/'                 : data_dir
+'/data/mta/Script/ACIS/Focal/Short_term/'           : short_term
 '/data/mta4/Script/Python3.10/MTA/'                 : mta_dir

--- a/ACIS_ft/house_keeping/dir_list
+++ b/ACIS_ft/house_keeping/dir_list
@@ -4,4 +4,4 @@
 '/data/mta/www/mta_fp/Plots/'                       : plot_dir
 '/data/mta/Script/ACIS/Focal/Data/'                 : data_dir
 '/data/mta/Script/ACIS/Focal/Short_term/'           : short_term
-'/data/mta/Script/Python3.8/MTA/'                   : mta_dir
+'/data/mta4/Script/Python3.10/MTA/'                 : mta_dir

--- a/ACIS_ft/house_keeping/dir_list
+++ b/ACIS_ft/house_keeping/dir_list
@@ -1,7 +1,7 @@
-'/data/mta/Script/ACIS/Focal/Script/'               : bin_dir
-'/data/mta/Script/ACIS/Focal/Script/house_keeping/' : house_keeping
-'/data/mta/www/mta_fp/'                             : web_dir
-'/data/mta/www/mta_fp/Plots/'                       : plot_dir
-'/data/mta/Script/ACIS/Focal/Data/'                 : data_dir
-'/data/mta/Script/ACIS/Focal/Short_term/'           : short_term
+'/data/mta4/testACIS/Focal/Script/'               : bin_dir
+'/data/mta4/testACIS/Focal/Script/house_keeping/' : house_keeping
+'/data/mta4/testACIS/Focal/web/'                             : web_dir
+'/data/mta4/testACIS/Focal/web/Plots/'                       : plot_dir
+'/data/mta4/testACIS/Focal/Data/'                 : data_dir
+'/data/mta4/testACIS/Focal/Short_term/'           : short_term
 '/data/mta4/Script/Python3.10/MTA/'                 : mta_dir

--- a/ACIS_ft/house_keeping/ft_main_template
+++ b/ACIS_ft/house_keeping/ft_main_template
@@ -84,7 +84,7 @@ Or select week # to open a detail plot of the week.
 <hr />
 <p style='padding-top;5px;padding-bottom:5px;'>
 If you have any questions about this page, please contact
-<a href='mailto:swolk@cfa.harvard.edu'>swolk@cfa.harvard.edu</a>
+<a href='mailto:tisobe@cfa.harvard.edu'>tisobe@cfa.harvard.edu</a>
 </p>
 <p style='padding-bottom:5px;'>
 <em>Last Modified: May 25, 2018</em>

--- a/ACIS_ft/house_keeping/ft_main_template
+++ b/ACIS_ft/house_keeping/ft_main_template
@@ -84,7 +84,7 @@ Or select week # to open a detail plot of the week.
 <hr />
 <p style='padding-top;5px;padding-bottom:5px;'>
 If you have any questions about this page, please contact
-<a href='mailto:tisobe@cfa.harvard.edu'>tisobe@cfa.harvard.edu</a>
+<a href='mailto:swolk@cfa.harvard.edu'>swolk@cfa.harvard.edu</a>
 </p>
 <p style='padding-bottom:5px;'>
 <em>Last Modified: May 25, 2018</em>

--- a/ACIS_ft/update_base_data.py
+++ b/ACIS_ft/update_base_data.py
@@ -18,7 +18,7 @@ import numpy
 import getopt
 import time
 import Chandra.Time
-import Ska.engarchive.fetch as fetch
+#import Ska.engarchive.fetch as fetch
 import random
 import unittest
 #

--- a/ACIS_ft/update_base_data.py
+++ b/ACIS_ft/update_base_data.py
@@ -12,15 +12,11 @@
 
 import sys
 import os
-import string
 import re
-import getopt
-import time
 import Chandra.Time
-#import Ska.engarchive.fetch as fetch
-import random
 import unittest
 import getpass
+import glob
 #
 #--- from ska
 #
@@ -48,11 +44,6 @@ sys.path.append(mta_dir)
 sys.path.append(bin_dir)
 
 import mta_common_functions     as mcf
-#
-#--- temp writing file name
-#
-rtail  = int(time.time() * random.random())
-zspace = '/tmp/zspace' + str(rtail)
 
 #-------------------------------------------------------------------------------
 #-- update_base_data: update acis focal temperature data files                --
@@ -79,6 +70,7 @@ def update_base_data():
     cmd   = 'ls /dsops/GOT/input/*_Dump_EM_*.gz > ' + ifile
     os.system(cmd)
     clist = mcf.read_data_file(ifile)
+    
 #
 #--- find which ones are not processed yet
 #
@@ -151,14 +143,9 @@ class TestFunctions(unittest.TestCase):
 
 #-------------------------------------------------------------------------------
     def test_extract_data_from_dump(self):
-
-        cmd = 'ls  /dsops/GOT/input/*Dump_EM*gz > ' + zspace
-        os.system(cmd)
-        data = mcf.read_data_file(zspace, remove=1)
-        nlist = [data[-1],]
-
+        data = glob.glob('/dsops/GOT/input/*Dump_EM*gz')
+        nlist = [data[-1]]
         plist = extract_data_from_dump(nlist, test=1)
-        
         data  = mcf.read_data_file('./short_term_test', remove=1)
 
         if len(data) > 0:

--- a/ACIS_ft/update_base_data.py
+++ b/ACIS_ft/update_base_data.py
@@ -26,8 +26,7 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release; setenv ACISTOOLSDIR /ho
 #
 #--- reading directory list
 #
-path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
-#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/ACIS_ft/update_base_data.py
+++ b/ACIS_ft/update_base_data.py
@@ -30,7 +30,8 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release; setenv ACISTOOLSDIR /ho
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
+path = '/data/mta4/testACIS/Focal/Script/house_keeping/dir_list'
+#path = '/data/mta/Script/ACIS/Focal/Script/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]


### PR DESCRIPTION
This PR addressed issues #4 by updating to Ska3/flight environment, implementing lock files, unit testing, as well as reducing some dependency on MTA common functions by replacing the add_leading_zeros function with zfill as well  as the text file reader.

Testing:
This set of script is tested in the "/data/mta4/testACIS/Focal" test directory, with the scripts symlinked to the git version, running as mta@c3po-v. It operates on a separate copied data directory pulled from "/data/mta/Script/ACIS/Focal/Data". 

Final Implementation Steps:
1. Revert pathing from test directories to live directories
2. Copy current live scripts to a Scripts3.8 adjacent directory
3. Copy python, main, wrap, and perl scripts to live running
4. Remove disk-bloat by removing backup tilde files in data directory.
5. Remove Save2 and Save_xxx data directories.