### PR TITLE
Typo correction

### DIFF
--- a/Python_scripts/robust_linear.py
+++ b/Python_scripts/robust_linear.py
@@ -7,18 +7,12 @@
 #                                                                                           #
 #           author: t. isobe (tisobe@cfa.harvard.edu)                                       #
 #                                                                                           #
-#           Last update:     Mar 15, 2021                                                   #
+#           Last update:     Feb 29, 2024                                                   #
 #                                                                                           #
 #############################################################################################
 
-import os
-import sys
-import re
-import string
 import random
-import operator
 import math
-import numpy
 
 #-------------------------------------------------------------------------------------------
 #-- robust_fit: compute a linear fit parameters using rubst fit                          ---
@@ -116,10 +110,10 @@ def medfit(xval, yval):
 #
     (aa, bb, delta) = least_sq(xval, yval)
 #
-#--- save the values for the case the values did not converse
+#--- save the values for the case the values did not converge
 #
     asave = aa
-    basve = bb
+    bsave = bb
 
     chisq = 0.0
     for j in range(0, tot):


### PR DESCRIPTION
Correct minor typo in robust_linear python module, as well as removing unused modules. This correction removes a possible edge case in which robust linear is used to fit non-converging data.