### PR TITLE
Test run comp

### DIFF
--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -287,11 +287,11 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
                         if dtype == 'short':
                             cut   = etime - 86400 * 548
-                            remove_old_data_from_fits(dfile, cut, dtype)
+                            remove_old_data_from_fits(dfile, cut)
 
                         elif dtype == 'week':
                             cut   = etime - 86400 * 7
-                            remove_old_data_from_fits(dfile, cut, dtype)
+                            remove_old_data_from_fits(dfile, cut)
                     else:
                         cmd = 'mv ' + appendfile + ' ' +  dfile
                         os.system(cmd)
@@ -676,12 +676,11 @@ def create_fits_table(msid, data):
 #-- remove_old_data_from_fits: remove old part of the data from fits file      --
 #--------------------------------------------------------------------------------
 
-def remove_old_data_from_fits(fits, cut, dtype):
+def remove_old_data_from_fits(fits, cut):
     """
     remove old part of the data from fits file
     input:  fits    --- fits file name
             cut     --- cut date in seconds from 1998.1.1
-            dtype   --- data file type
     output: fits    --- updated fits file
     """
 #

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -220,6 +220,11 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
             dfile = f"{DATA_DIR}/{gname}/{ofile}"
 #
+#--- If the FULL_GEN option is set to true, then remove this file to fully regenerate it
+#
+            if os.path.isfile(dfile) and FULL_GEN:
+                os.remove(dfile)
+#
 #--- find the last entry time
 #
             tstart = find_last_entry_time(dfile, dtype, etime)
@@ -320,7 +325,7 @@ def find_last_entry_time(dfile, dtype, today):
 #
 #--- check the previous fits data file exists. if it does, find the last entry time
 #
-    if os.path.isfile(dfile) and not FULL_GEN:
+    if os.path.isfile(dfile):
         hdout = pyfits.open(dfile)
         data  = hdout[1].data
         dtime = data['time']
@@ -747,7 +752,6 @@ if __name__ == "__main__":
 
         if args.full is not None:
             FULL_GEN = args.full
-
         if args.data:
             DATA_DIR = args.data
         else:

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -710,10 +710,19 @@ def remove_old_data_from_fits(fits, cut):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
-    parser.add_argument("-p", "--path", help = "Determine data output file path")
+    parser.add_argument("-d", "--data", help = "Determine Data output file path")
+    parser.add_argument("--deposit", help = "Determine Deposit input file path")
     args = parser.parse_args()
     
     if args.mode == 'test':
+
+        if args.data:
+            DATA_DIR = args.data
+        else:
+            DATA_DIR = f"{os.getcwd()}/test/outTest"
+            os.makedirs(DATA_DIR, exist_ok=True)
+        if args.deposit:
+            DEPOSIT_DIR = args.deposit
 
         run_comp_grad_data_update()
 

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -40,7 +40,6 @@ sys.path.append(MTA_DIR)
 #
 #--- import several functions
 #
-import mta_common_functions     as mcf  #---- contains other functions commonly used in MTA scripts
 import envelope_common_function as ecf  #---- contains other functions commonly used in envelope
 import fits_operation           as mfo  #---- fits operation collection
 import read_limit_table         as rlt  #---- read limit table and create msid<--> limit dict
@@ -160,9 +159,7 @@ def run_comp_grad_data_update():
 #--- compress the last year's fits file
 #
     if yday >= 3 and yday < 5:
-        lyear = year - 1
-        cmd =  'gzip -fq ' + deposit_dir + '*/*/*_full_data_' + str(lyear) + '.fits'
-        os.system(cmd)
+        os.system(f"gzip -fq {DEPOSIT_DIR}/*/*/*_full_data_{eyear - 1}.fits")
 
 #--------------------------------------------------------------------------------
 #-- update_comp_data: update comp/grad related msid data                       --
@@ -650,8 +647,9 @@ def create_fits_file(msid, data, dtype):
         ofits = msid + '_short_data.fits'
     else:
         ofits = msid + '_data.fits'
-    
-    mcf.rm_files(ofits)
+
+    if os.path.isfile(ofits):
+        os.remove(ofits)
 
     tbhdu.writeto(ofits)
 
@@ -697,7 +695,8 @@ def remove_old_data_from_fits(fits, cut):
     os.system(cmd)
     try:
         create_fits_file(fits, cols, udata)
-        mcf.rm_file(sfits)
+        if os.path.isfile(sfits):
+            os.remove(sfits)
     except:
         cmd = 'mv ' + sfits + ' ' + fits
         os.system(cmd)

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -40,7 +40,6 @@ sys.path.append(MTA_DIR)
 #
 #--- import several functions
 #
-import envelope_common_function as ecf  #---- contains other functions commonly used in envelope
 import fits_operation           as mfo  #---- fits operation collection
 import read_limit_table         as rlt  #---- read limit table and create msid<--> limit dict
 
@@ -154,7 +153,7 @@ def run_comp_grad_data_update():
         try:
             update_comp_data(group_name[k], g_msid_list[k], eyear, etime)
         except:
-            print("Something went wrong while analyzing: " + g_msid_list[k])
+            traceback.print_exc()
 #
 #--- compress the last year's fits file
 #
@@ -241,7 +240,7 @@ def update_comp_data(gname, msid_list, eyear, etime):
                             cmd = 'mv ./temp.fits ' +  dfile
                             os.system(cmd)
                         except:
-                            pass
+                            traceback.print_exc()
 #
 #--- check the file is actually updated. if not put back the old one 
 #
@@ -451,6 +450,7 @@ def run_condtion_msid(msid, fits, start, stop, period, alimit, cnd_msid):
             limit_table = find_limits(begin, mkey, alimit)
             [y_low, y_top, r_low, r_top] = limit_table
         except:
+            traceback.print_exc()
             limit_table = [-9999998.0, 9999998.0, -9999999.0, 9999999.0]
             [y_low, y_top, r_low, r_top] = [-9999998.0, 9999998.0, -9999999.0, 9999999.0]
 #
@@ -598,6 +598,7 @@ def find_limits(stime, mkey, alimit):
             try:
                 ltable = alimit[k][3][mkey]
             except:
+                traceback.print_exc()
                 ltable = alimit[k][3]['none']
             break 
 
@@ -700,6 +701,8 @@ def remove_old_data_from_fits(fits, cut):
     except:
         cmd = 'mv ' + sfits + ' ' + fits
         os.system(cmd)
+        print(f'Error making :{fits}, moving back.')
+        traceback.print_exc()
 
 #--------------------------------------------------------------------------------
 

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -6,38 +6,37 @@
 #                                                                                           #
 #           author: t. isobe (tisobe@cfa.harvard.edu)                                       #
 #                                                                                           #
-#           last update: Feb 02, 2021                                                       #
+#           last update: May 06, 2024                                                       #
 #                                                                                           #
 #############################################################################################
 
 import os
 import sys
 import re
-import string
 import time
 import numpy
 import astropy.io.fits  as pyfits
 from astropy.io.fits import Column
 import Ska.engarchive.fetch as fetch
 import Chandra.Time
+import traceback
+import argparse
 import getpass
 #
-#--- reading directory list
+#--- Define Directory Pathing
 #
-path = '/data/mta/Script/MTA_limit_trends/Scripts/house_keeping/dir_list'
-with open(path, 'r') as f:
-    data = [line.strip() for line in f.readlines()]
+BIN_DIR = "/data/mta/Script/MTA_limit_trends/Scripts"
+MTA_DIR = "/data/mta4/Script/Python3.11/MTA"
+DEPOSIT_DIR = "/data/mta/Script/MTA_limit_trends/Deposit"
+COMP_DIR = f"{DEPOSIT_DIR}/Comp_Save"
+GRAD_DIR = f"{DEPOSIT_DIR}/Grad_Save"
+DATA_DIR = "/data/mta/Script/MTA_limit_trends/Data"
 
-for ent in data:
-    atemp = re.split(':', ent)
-    var  = atemp[1].strip()
-    line = atemp[0].strip()
-    exec("%s = %s" %(var, line))
 #
 #--- append path to a private folder
 #
-sys.path.append(bin_dir)
-sys.path.append(mta_dir)
+sys.path.append(BIN_DIR)
+sys.path.append(MTA_DIR)
 #
 #--- import several functions
 #
@@ -45,11 +44,7 @@ import mta_common_functions     as mcf  #---- contains other functions commonly 
 import envelope_common_function as ecf  #---- contains other functions commonly used in envelope
 import fits_operation           as mfo  #---- fits operation collection
 import read_limit_table         as rlt  #---- read limit table and create msid<--> limit dict
-#
-#--- other path setting
-#
-comp_dir  = deposit_dir + 'Comp_save/'
-grad_dir  = deposit_dir + 'Grad_save/'
+
 #
 #--- fits generation related lists
 #
@@ -190,11 +185,11 @@ def update_comp_data(gname, msid_list, eyear, etime):
         mc2 = re.search('comp', gname.lower())
         if mc is not None:
             if mc2 is not None:
-                sub_dir = comp_dir
+                sub_dir = COMP_DIR
             else:
-                sub_dir = grad_dir
+                sub_dir = GRAD_DIR
         else:
-            sub_dir = comp_dir
+            sub_dir = COMP_DIR
 #
 #--- set limit data (a list of lists of limit values)
 #
@@ -208,7 +203,7 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
 #--- database file name
 #
-            dfile  = data_dir + gname + '/' + ofile
+            dfile = f"{DATA_DIR}/{gname}/{ofile}"
 #
 #--- find the last entry time
 #
@@ -224,9 +219,9 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
 #--- set the input fits file name
 #
-                fits = sub_dir + gname + '/' + msid + '_full_data_' + str(year) + '.fits'
+                fits = f"{sub_dir}/{gname}/{msid}_full_data_{year}.fits"
                 if not os.path.isfile(fits):
-                    fits = sub_dir +  gname + '/' + msid + '_full_data_' + str(year) + '.fits.gz'
+                    fits = f"{sub_dir}/{gname}/{msid}_full_data_{year}.fits.gz"
                     if not os.path.isfile(fits):
                         continue
 #

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -278,11 +278,11 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
                         if dtype == 'short':
                             cut   = etime - 86400 * 548
-                            remove_old_data_from_fits(dfile, cut)
+                            remove_old_data_from_fits(dfile, cut, dtype)
 
                         elif dtype == 'week':
                             cut   = etime - 86400 * 7
-                            remove_old_data_from_fits(dfile, cut)
+                            remove_old_data_from_fits(dfile, cut, dtype)
                     else:
                         cmd = 'mv ' + out + ' ' +  dfile
                         os.system(cmd)
@@ -680,11 +680,12 @@ def create_fits_file(msid, data, dtype):
 #-- remove_old_data_from_fits: remove old part of the data from fits file      --
 #--------------------------------------------------------------------------------
 
-def remove_old_data_from_fits(fits, cut):
+def remove_old_data_from_fits(fits, cut, dtype):
     """
     remove old part of the data from fits file
     input:  fits    --- fits file name
             cut     --- cut date in seconds from 1998.1.1
+            dtype   --- data file type
     output: fits    --- updated fits file
     """
 #
@@ -715,7 +716,7 @@ def remove_old_data_from_fits(fits, cut):
     cmd   = 'mv ' + fits + ' ' + sfits
     os.system(cmd)
     try:
-        create_fits_file(fits, cols, udata)
+        create_fits_file(col_list[1], udata, dtype)
         if os.path.isfile(sfits):
             os.remove(sfits)
     except:

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -29,8 +29,8 @@ import getpass
 BIN_DIR = "/data/mta/Script/MTA_limit_trends/Scripts"
 MTA_DIR = "/data/mta4/Script/Python3.11/MTA"
 DEPOSIT_DIR = "/data/mta/Script/MTA_limit_trends/Deposit"
-COMP_DIR = f"{DEPOSIT_DIR}/Comp_Save"
-GRAD_DIR = f"{DEPOSIT_DIR}/Grad_Save"
+COMP_DIR = f"{DEPOSIT_DIR}/Comp_save"
+GRAD_DIR = f"{DEPOSIT_DIR}/Grad_save"
 DATA_DIR = "/data/mta/Script/MTA_limit_trends/Data"
 
 #
@@ -48,6 +48,7 @@ import read_limit_table         as rlt  #---- read limit table and create msid<-
 #--- Define globals
 #
 FULL_GEN = False #Used for determining whether to generate the fill fits files or build off the last time entry
+DTYPE = ['long', 'short', 'week']
 #
 #--- fits generation related lists
 #
@@ -209,7 +210,7 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
         alimit   = lim_dict[msid]
 
-        for dtype in ['long', 'short', 'week']:
+        for dtype in DTYPE:
             if dtype == 'long':
                 ofile = msid + '_data.fits'
             else:
@@ -235,8 +236,9 @@ def update_comp_data(gname, msid_list, eyear, etime):
 #
                 fits = f"{sub_dir}/{gname}/{msid}_full_data_{year}.fits"
                 if not os.path.isfile(fits):
-                    fits = f"{sub_dir}/{gname}/{msid}_full_data_{year}.fits.gz"
+                    fits = f"{fits}.gz"
                     if not os.path.isfile(fits):
+                        print(f"Could not find {fits[:-3]} or gz.")
                         continue
 #
 #--- extract the data part needed and save in a fits file 
@@ -729,9 +731,13 @@ if __name__ == "__main__":
     parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
     parser.add_argument("-d", "--data", help = "Determine Data output file path.")
     parser.add_argument("--deposit", help = "Determine Deposit input file path.")
+    parser.add_argument("-t",'--dtype', nargs = '*', required = False, choices = ['long', 'short', 'week'], help = "List of data types to generate.")
     parser.add_argument('--full',help = "Determine whether to full regenerate fits, or use the last recorded time entry.", action=argparse.BooleanOptionalAction)
     args = parser.parse_args()
     
+    if args.dtype:
+        DTYPE = args.dtype
+
     if args.mode == 'test':
         #Smaller test subset
         GROUP_MSID_DICT = {

--- a/MTA_limit_trends/Comp/run_comp_grad_data_update.py
+++ b/MTA_limit_trends/Comp/run_comp_grad_data_update.py
@@ -190,7 +190,7 @@ def update_comp_data(gname, msid_list, eyear, etime):
             etime       --- today's date in seconds from 1998.1.1
     output: <data_dir>/<gname>/<msid>_<dtye>_data.fits
     """
-    #make the group suibdirectory in case it doesn't exist
+    #make the group subdirectory in case it doesn't exist
     os.makedirs(f"{DATA_DIR}/{gname}", exist_ok=True)
     for msid in msid_list:
 #

--- a/MTA_limit_trends/mta_limit_deposit_main_script
+++ b/MTA_limit_trends/mta_limit_deposit_main_script
@@ -6,5 +6,5 @@ cd /data/mta/Script/MTA_limit_trends/Exc2
 /data/mta/Script/MTA_limit_trends/Scripts/Deposit/update_sim_flex.py
 /data/mta/Script/MTA_limit_trends/Scripts/Deposit/process_dea_data_full.py
 
-/data/mta/Script/MTA_limit_trends/Scripts/Comp/run_comp_grad_data_update.py
+/data/mta/Script/MTA_limit_trends/Scripts/Comp/run_comp_grad_data_update.py -m flight
 


### PR DESCRIPTION
This PR implements testing methods and file appending fixes to the deposit set of MTA limit trending scripts. These changes are in response to needing to regenerate the HRMAAVG plotting fits files following the discovery of using OHRTHR28 to incorrectly calculate the HRMAAVG value.

The testing implementations mimics those seen in previous MTA changes with changing directory pathing to a set of string globals which can be altered from the command line, therefore allowing the script to be testable without interfering with live running.