### PR TITLE
Python3.11 mta

### DIFF
--- a/Python_scripts/dir_list
+++ b/Python_scripts/dir_list
@@ -1,0 +1,3 @@
+'/data/mta4/Script/Python3.11/MTA/'                           : mta_dir
+'/data/mta4/Script/Python3.11/lib/python3.11/site-packages/'   : sp_dir
+

--- a/Python_scripts/fits_operation.py
+++ b/Python_scripts/fits_operation.py
@@ -20,7 +20,7 @@ import math
 import numpy
 import astropy.io.fits  as pyfits
 
-sys.path.append('/data/mta4/Script/Python3.10/MTA')
+sys.path.append('/data/mta4/Script/Python3.11/MTA')
 #
 import mta_common_functions    as mcf        #---- contains other functions commonly used in MTA scripts
 

--- a/Python_scripts/fits_operation.py
+++ b/Python_scripts/fits_operation.py
@@ -22,7 +22,6 @@ import astropy.io.fits  as pyfits
 
 sys.path.append('/data/mta4/Script/Python3.11/MTA')
 #
-import mta_common_functions    as mcf        #---- contains other functions commonly used in MTA scripts
 
 #-------------------------------------------------------------------------------------------------------
 #-- findKeyWords: for a given fits file name, return a list of keyword lists and their values         --
@@ -205,7 +204,8 @@ def selectTableData(ifile, colname, condition, outname, extension = 1, clobber='
     m2 = re.search('Y', clobber)
 
     if (m1 is not None) or (m2 is not None):
-        mcf.rm_files(outname)
+        if os.path.isfile(outname):
+            os.remove(outname)
 
     t     = pyfits.open(ifile)
     tdata = t[extension].data
@@ -325,7 +325,13 @@ def set_format_for_col(name, cdata):
 #
 #--- check whether the value is numeric
 #
-    if mcf.is_neumeric(test):
+    try:
+        var = float(test)
+        var = True
+    except:
+        var = False
+    
+    if var:
         ft = 'E'
 #
 #--- check whether the value is logical
@@ -464,7 +470,8 @@ def fitsImgSection(ifile, x1, x2, y1, y2, outname, extension=0, clobber='no'):
     m1 = re.search('y', clobber)
     m2 = re.search('Y', clobber)
     if (m1 is not None) or (m2 is not None):
-        mcf.rm_files(outname)
+        if os.path.isfile(outname):
+            os.remove(outname)
 
     t    = pyfits.open(ifile)
     data = t[extension].data

--- a/Python_scripts/gamma_function.py
+++ b/Python_scripts/gamma_function.py
@@ -32,7 +32,7 @@ import matplotlib.lines as lines
 #
 #--- reading directory list
 #
-path = '/data/mta/Script/Python3.10/MTA/house_keeping/dir_list'
+path = '/data/mta/Script/Python3.11/MTA/house_keeping/dir_list'
 
 with open(path, 'r') as f:
     data = [line.strip() for line in f.readlines()]

--- a/Python_scripts/gamma_function.py
+++ b/Python_scripts/gamma_function.py
@@ -48,10 +48,6 @@ for ent in data:
 sys.path.append(bin_dir)
 sys.path.append(mta_dir)
 #
-#--- import several functions
-#
-import mta_common_functions as mcf  #---- contains other functions commonly used in MTA scripts
-#
 #--- temp writing file name
 #
 import random
@@ -208,7 +204,8 @@ def gamma_fit(x, y, a0, b0, m0):
 
 def read_data(dfile):
 
-    data  = mcf.read_data_file(dfile)
+    with open(dfile) as f:
+        data = [line.strip() for line in f.readlines()]
     fdata = []
     for ent in data:
         fdata.append(int(float(ent)))

--- a/Python_scripts/house_keeping/dir_list
+++ b/Python_scripts/house_keeping/dir_list
@@ -1,3 +1,3 @@
-'/data/mta4/Script/Python3.10/MTA/'                   : mta_dir
-'/data/mta4/Script/Python3.10/MTA/house_keeping/'     : house_keeping
+'/data/mta4/Script/Python3.11/MTA/'                   : mta_dir
+'/data/mta4/Script/Python3.11/MTA/house_keeping/'     : house_keeping
 '/data/mta4/CUS/www/Usint/Pass_dir/'                : pass_dir

--- a/Python_scripts/mta_common_functions.py
+++ b/Python_scripts/mta_common_functions.py
@@ -33,7 +33,7 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release; source /home/mta/bin/re
 tail = int(time.time() * random.random())
 zspace = '/tmp/zspace' + str(tail)
 
-house_keeping = '/data/mta/Script/Python3.10/MTA/'
+house_keeping = '/data/mta/Script/Python3.11/MTA/'
 
 #--------------------------------------------------------------------------
 #-- read_data_file: read a data file and create a data list              --

--- a/Python_scripts/mta_convert_fits_to_image.py
+++ b/Python_scripts/mta_convert_fits_to_image.py
@@ -24,7 +24,7 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
 #
 #--- add mta common function
 #
-mta_dir = '/data/mta4/Script/Python3.10/MTA/'
+mta_dir = '/data/mta4/Script/Python3.11/MTA/'
 sys.path.append(mta_dir)
 import mta_common_functions as mcf
 #

--- a/Python_scripts/mta_convert_fits_to_image.py
+++ b/Python_scripts/mta_convert_fits_to_image.py
@@ -26,7 +26,6 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
 #
 mta_dir = '/data/mta4/Script/Python3.11/MTA/'
 sys.path.append(mta_dir)
-import mta_common_functions as mcf
 #
 rtail  = int(time.time() * random.random())
 zspace = '/tmp/zspace' + str(rtail)
@@ -65,7 +64,8 @@ def mta_convert_fits_to_image(infile, outfile, scale = 'log', \
 #
     cmd  = 'ls /home/ascds/DS.release/data/*.lut > ' + zspace
     os.system(cmd)
-    data = mcf.read_data_file(zspace)
+    with open(zspace) as f:
+        data = [line.strip() for line in f.readlines()]
 
     color_list = []
     for ent in data:

--- a/Python_scripts/mta_convert_fits_to_image2.py
+++ b/Python_scripts/mta_convert_fits_to_image2.py
@@ -24,7 +24,7 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
 #
 #--- add mta common function
 #
-mta_dir = '/data/mta4/Script/Python3.10/MTA/'
+mta_dir = '/data/mta4/Script/Python3.11/MTA/'
 sys.path.append(mta_dir)
 import mta_common_functions as mcf
 #

--- a/Python_scripts/mta_convert_fits_to_image2.py
+++ b/Python_scripts/mta_convert_fits_to_image2.py
@@ -26,7 +26,6 @@ ascdsenv = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
 #
 mta_dir = '/data/mta4/Script/Python3.11/MTA/'
 sys.path.append(mta_dir)
-import mta_common_functions as mcf
 #
 rtail  = int(time.time() * random.random())
 zspace = '/tmp/zspace' + str(rtail)
@@ -65,7 +64,8 @@ def mta_convert_fits_to_image(infile, outfile, scale = 'log', \
 #
     cmd  = 'ls /home/ascds/DS.release/data/*.lut > ' + zspace
     os.system(cmd)
-    data = mcf.read_data_file(zspace)
+    with open(zspace) as f:
+        data = [line.strip() for line in f.readlines()]
 
     color_list = []
     for ent in data:

--- a/Python_scripts/plotting_routine_set.py
+++ b/Python_scripts/plotting_routine_set.py
@@ -44,7 +44,7 @@ import matplotlib.lines        as lines
 #
 #--- reading directory list
 #
-path = '/data/mta4/Script/Python3.10/MTA/dir_list'
+path = '/data/mta4/Script/Python3.11/MTA/dir_list'
 
 f    = open(path, 'r')
 data = [line.strip() for line in f.readlines()]


### PR DESCRIPTION
This PR is a small update to the MTA specific library of functions to remove the use of mcf from within the functions themselves. Considering the possible import error for mcf, this now removes mcf library imports hidden in other MTA library scripts, making ti easier to avoid stalling.